### PR TITLE
fix: multiple anchor links

### DIFF
--- a/docs/en/about/about.md
+++ b/docs/en/about/about.md
@@ -1,6 +1,6 @@
 # About TODS
 
-The Transit Operational Data Standard ("TODS") is managed by [MobilityData](https://mobilitydata.org) serving as the [TODS Manager](../governance/governance.md#TODS-manager) under the authority of the [TODS Board](../governance/governance.md#TODS-board-of-directors) with basic monetary support through 2025 from the [California Integrated Travel Project (Cal-ITP)](https://cal-itp.org).
+The Transit Operational Data Standard ("TODS") is managed by [MobilityData](https://mobilitydata.org) serving as the [TODS Manager](../governance/governance.md#tods-manager) under the authority of the [TODS Board](../governance/governance.md#tods-board-of-directors) with basic monetary support through 2025 from the [California Integrated Travel Project (Cal-ITP)](https://cal-itp.org).
 
 TODS was [initially developed](spec-development.md) in 2021-2022 by the [TODS Working Group](contributors.md) (now known as *contributors*) using resources from the [California Integrated Travel Project (Cal-ITP)](https://cal-itp.org) in order to:
 

--- a/docs/en/about/spec-development.md
+++ b/docs/en/about/spec-development.md
@@ -64,5 +64,5 @@ Recognizing that a State DOT is not the ideal place to manage a data standard, i
 In January 2024:
 
 - the day-to-day management of the TODS standard will be assumed by [MobilityData](https://mobilitydata.org), the same organization that manages [GTFS](https://gtfs.org) (upon which TODS relies); and
-- the ownership and key decisions about TODS will be transfered from Cal-ITP to an [independent board](../governance/governance.md#TODS-board-of-directors) composed of transit agencies, and both schedule and CAD/AVL vendors.
+- the ownership and key decisions about TODS will be transfered from Cal-ITP to an [independent board](../governance/governance.md#tods-board-of-directors) composed of transit agencies, and both schedule and CAD/AVL vendors.
 - future spec development will be governed by the [change management and versioning policy](../governance/policies/change-management-versioning.md)

--- a/docs/en/governance/governance.md
+++ b/docs/en/governance/governance.md
@@ -44,7 +44,7 @@ The TODS Project encompasses:
 
 Who and how decisions are made about the scope and direction of the TODS Project, including but not limited to the approved [roles and responsibilities](#roles) and the following policies:
 
-- [TODS Change Management and Versioning Policy](#tods-change-management--versioning-policy)
+- [TODS Change Management and Versioning Policy](#tods-change-management-versioning-policy)
 - [TODS Contributor Agreement](#tods-contributor-agreement)
 - [TODS Code of Conduct](#tods-code-of-conduct)
 - [TODS Use License](#tods-use-license)


### PR DESCRIPTION
When building the site there were many warnings about anchor links that were not found. They were improperly formatted.

Tested and no error or warnings appeared.